### PR TITLE
[issue #10] Implement fund_escrow function

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -5,8 +5,127 @@ version = 1
 name = "escrownet_contract"
 version = "0.1.0"
 dependencies = [
+ "openzeppelin",
  "snforge_std",
 ]
+
+[[package]]
+name = "openzeppelin"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:05fd9365be85a4a3e878135d5c52229f760b3861ce4ed314cb1e75b178b553da"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_finance",
+ "openzeppelin_governance",
+ "openzeppelin_introspection",
+ "openzeppelin_merkle_tree",
+ "openzeppelin_presets",
+ "openzeppelin_security",
+ "openzeppelin_token",
+ "openzeppelin_upgrades",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_access"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:7734901a0ca7a7065e69416fea615dd1dc586c8dc9e76c032f25ee62e8b2a06c"
+dependencies = [
+ "openzeppelin_introspection",
+]
+
+[[package]]
+name = "openzeppelin_account"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:1aa3a71e2f40f66f98d96aa9bf9f361f53db0fd20fa83ef7df04426a3c3a926a"
+dependencies = [
+ "openzeppelin_introspection",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_finance"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:f0c507fbff955e4180ea3fa17949c0ff85518c40101f4948948d9d9a74143d6c"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_token",
+]
+
+[[package]]
+name = "openzeppelin_governance"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:c0fb60fad716413d537fabd5fcbb2c499ca6beb95af5f0d1699955ecec4c6f63"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_introspection",
+ "openzeppelin_token",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_introspection"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:13e04a2190684e6804229a77a6c56de7d033db8b9ef519e5e8dee400a70d8a3d"
+
+[[package]]
+name = "openzeppelin_merkle_tree"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:039608900e92f3dcf479bf53a49a1fd76452acd97eb86e390d1eb92cacdaf3af"
+
+[[package]]
+name = "openzeppelin_presets"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:5c07a8de32e5d9abe33988c7927eaa8b5f83bc29dc77302d9c8c44c898611042"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_finance",
+ "openzeppelin_introspection",
+ "openzeppelin_token",
+ "openzeppelin_upgrades",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_security"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:27155597019ecf971c48d7bfb07fa58cdc146d5297745570071732abca17f19f"
+
+[[package]]
+name = "openzeppelin_token"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:4452f449dc6c1ea97cf69d1d9182749abd40e85bd826cd79652c06a627eafd91"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_introspection",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_upgrades"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:15fdd63f6b50a0fda7b3f8f434120aaf7637bcdfe6fd8d275ad57343d5ede5e1"
+
+[[package]]
+name = "openzeppelin_utils"
+version = "0.20.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:44f32d242af1e43982decc49c563e613a9b67ade552f5c3d5cde504e92f74607"
 
 [[package]]
 name = "snforge_scarb_plugin"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -7,6 +7,7 @@ edition = "2023_11"
 
 [dependencies]
 starknet = "2.8.2"
+openzeppelin = "0.20.0"
 
 [dev-dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.31.0" }

--- a/src/escrow/escrow_contract.cairo
+++ b/src/escrow/escrow_contract.cairo
@@ -127,7 +127,7 @@ mod EscrowContract {
         }
 
         // map address to true
-        self.depositor_approve.entry(address).write(true);
+        self.depositor_approve.write(address, true);
         let timestamp = get_block_timestamp();
 
         // Emit the event

--- a/src/escrow/escrow_contract.cairo
+++ b/src/escrow/escrow_contract.cairo
@@ -99,12 +99,17 @@ mod EscrowContract {
     }
 
     fn fund_escrow(ref self: ContractState, escrow_id:u64, amount: u256, token_address: ContractAddress ) {
+        // check if escrow exists
+        assert(self.escrow_exists.entry(escrow_id).read(), 'Escrow not exists.');
         // seting needed variables
         let depositor = self.depositor.read();
         let caller_address = get_caller_address();
         let contract_address = get_contract_address();
+        let expected_amount = self.escrow_amounts.entry(escrow_id).read();
         // Make an assert the check if the caller address is the same as the depositor address.
         assert(depositor==caller_address, 'Only depositor can fund.');
+        // Check that the correct amount was sended.
+        assert(amount>=expected_amount, 'Amount is less than expected');
         // Use the OpenZeppelin ERC20 contract to transfer the fund from the caller address to the scrow contract.
         let token = IERC20Dispatcher { contract_address: token_address };
         token.transfer_from(caller_address, contract_address, amount);

--- a/src/escrow/escrow_contract.cairo
+++ b/src/escrow/escrow_contract.cairo
@@ -17,7 +17,6 @@ mod EscrowContract {
         depositor_approve: Map::<ContractAddress, bool>,
         arbiter_approve: Map::<ContractAddress, bool>,
         escrow_balance: u256,
-        strk_address: ContractAddress
     }
 
     #[event]
@@ -51,7 +50,6 @@ mod EscrowContract {
         self.benefeciary.write(benefeciary);
         self.depositor.write(depositor);
         self.arbiter.write(arbiter);
-        self.strk_address.write(contract_address_const::<0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d>());
     }
 
 
@@ -84,7 +82,7 @@ mod EscrowContract {
             );
     }
 
-    fn fund_escrow(ref self: ContractState, amount: u256) {
+    fn fund_escrow(ref self: ContractState, amount: u256, token_address: ContractAddress ) {
         // seting needed variables
         let depositor = self.depositor.read();
         let caller_address = get_caller_address();
@@ -92,7 +90,7 @@ mod EscrowContract {
         // Make an assert the check if the caller address is the same as the depositor address.
         assert(depositor==caller_address, 'Only depositor can fund.');
         // Use the OpenZeppelin ERC20 contract to transfer the fund from the caller address to the scrow contract.
-        let token = IERC20Dispatcher { contract_address: self.strk_address.read() };
+        let token = IERC20Dispatcher { contract_address: token_address };
         token.transfer_from(caller_address, contract_address, amount);
         // Update the escrow's balance in the Storage 
         self.escrow_balance.write(self.escrow_balance.read() + amount);

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -42,6 +42,6 @@ fn test_cannot_increase_balance_with_zero_value() {
         Result::Ok(_) => core::panic_with_felt252('Should have panicked'),
         Result::Err(panic_data) => {
             assert(*panic_data.at(0) == 'Amount cannot be 0', *panic_data.at(0));
-        }
+        },
     };
 }


### PR DESCRIPTION
Implementation of the fund_escrow function to escrow_contract. The function implements the next algorithm:

- Make an assert the check if the caller address is the same as the depositor address.
- Use the OpenZeppelin ERC20 contract to transfer the fund from the caller address to the scrow contract.
- Update the escrow's balance in the Storage -> I create an escrow_balance variable on storage.
- Emit Escrow funded Event -> This event was created and added to the Events enum. 

I'm attentive to any fix/modification you want to make to this PR. Also you can contact me on tg -> j0xzerpa 

Happy Coding :)