### PR TITLE
feat: get_escrow_contracts

### DIFF
--- a/src/escrow/escrow_factory.cairo
+++ b/src/escrow/escrow_factory.cairo
@@ -12,6 +12,10 @@ pub trait IEscrowFactory<TContractState> {
         arbiter: ContractAddress,
         salt: felt252
     ) -> ContractAddress;
+
+    fn get_escrow_contracts(
+        ref self: TContractState
+    ) -> Array<ContractAddress>;
 }
 
 #[starknet::component]
@@ -58,6 +62,19 @@ pub mod EscrowFactory {
             self.escrow_count.write(escrow_id);
 
             escrow_address
+        }
+
+        fn get_escrow_contracts(
+            ref self: ComponentState<TContractState>
+        ) -> Array<ContractAddress> {
+            let escrow_count = self.escrow_count.read();
+            let mut escrow_addresses: Array<ContractAddress> = array![];
+
+            for i in 1..escrow_count {
+                escrow_addresses.append(self.escrow_addresses.read(i));
+            };
+
+            escrow_addresses
         }
     }
 }


### PR DESCRIPTION
Implemented a getter function for the escrow contracts deployed by the escrow factory. 

Looping from 1 to escrow_count and getting the values from the Map, into the array and returning it.
Closes #29 