### PR TITLE
[issue #10] write fund_escrow functionality

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -5,8 +5,123 @@ version = 1
 name = "escrownet_contract"
 version = "0.1.0"
 dependencies = [
+ "openzeppelin",
  "snforge_std",
 ]
+
+[[package]]
+name = "openzeppelin"
+version = "0.17.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:7e77855aaba0825a2a12cad72d52d85380a9fab732007754b3c5d98908918ce7"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_finance",
+ "openzeppelin_governance",
+ "openzeppelin_introspection",
+ "openzeppelin_merkle_tree",
+ "openzeppelin_presets",
+ "openzeppelin_security",
+ "openzeppelin_token",
+ "openzeppelin_upgrades",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_access"
+version = "0.17.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:541bb8fdf1ad17fe0d275b00acb9f0d7f56ea5534741e21535ac3fda2c600281"
+dependencies = [
+ "openzeppelin_introspection",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_account"
+version = "0.17.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:c4e11609fdd1f4c3d3004cd1468711bd2ea664739c9e59a4b270567fe4c23ee3"
+dependencies = [
+ "openzeppelin_introspection",
+ "openzeppelin_utils",
+]
+
+[[package]]
+name = "openzeppelin_finance"
+version = "0.17.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:9adcbec76ee8ed08be8d87c6af6014aa7080d67578816f5ba77f4376b25bc165"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_token",
+]
+
+[[package]]
+name = "openzeppelin_governance"
+version = "0.17.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:b7e0142d88d69a8c367aea8c9dc7f659f27372551efc23f39a0cf71a189c1302"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_introspection",
+]
+
+[[package]]
+name = "openzeppelin_introspection"
+version = "0.17.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:892433a4a1ea0fc9cf7cdb01e06ddc2782182abcc188e4ea5dd480906d006cf8"
+
+[[package]]
+name = "openzeppelin_merkle_tree"
+version = "0.17.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:3c338fa07cbaba8034051a42967816800abe535ef7d709a929175616603dccf9"
+
+[[package]]
+name = "openzeppelin_presets"
+version = "0.17.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:0a39e0effff133ab7fb003961ee2986438ee09b53608ce0d71aca24459879597"
+dependencies = [
+ "openzeppelin_access",
+ "openzeppelin_account",
+ "openzeppelin_finance",
+ "openzeppelin_introspection",
+ "openzeppelin_token",
+ "openzeppelin_upgrades",
+]
+
+[[package]]
+name = "openzeppelin_security"
+version = "0.17.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:6e2dee39d87f9ddec2ad37e33e80cf0d8b6c6927fd7950f220dbc2baea658d43"
+
+[[package]]
+name = "openzeppelin_token"
+version = "0.17.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:77997a7e217b69674c34b402dc0c7b2210540db66a56087572679c31896eaabb"
+dependencies = [
+ "openzeppelin_account",
+ "openzeppelin_governance",
+ "openzeppelin_introspection",
+]
+
+[[package]]
+name = "openzeppelin_upgrades"
+version = "0.17.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:a0fa5934f2924e1e85ec8f8c5b7dcd95c25295c029d3a745ba87b3191146004d"
+
+[[package]]
+name = "openzeppelin_utils"
+version = "0.17.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:36d93e353f42fd6b824abcd8b4b51c3f5d02c893c5f886ae81403b0368aa5fde"
 
 [[package]]
 name = "snforge_scarb_plugin"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -7,6 +7,7 @@ edition = "2023_11"
 
 [dependencies]
 starknet = "2.8.2"
+openzeppelin = "0.17.0"
 
 [dev-dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.31.0" }

--- a/src/escrow/escrow_contract.cairo
+++ b/src/escrow/escrow_contract.cairo
@@ -4,9 +4,10 @@ mod EscrowContract {
     use starknet::{ContractAddress, storage::Map, contract_address_const};
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess, StoragePathEntry};
     use starknet::get_block_timestamp;
-    use core::starknet::{get_caller_address};
+    use core::starknet::{get_caller_address, get_contract_address};
     use crate::escrow::{types::Escrow, errors::Errors};
     use crate::interface::iescrow::{IEscrow};
+    use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
 
     #[storage]
     struct Storage {
@@ -24,6 +25,8 @@ mod EscrowContract {
         escrow_exists: Map::<u64, bool>,
         // Store escrow amounts
         escrow_amounts: Map::<u64, u256>,
+        // Track the funded escrows. Start as false and is setted to true when successfully funds.
+        escrow_funded: Map::<u64, bool>,
     }
 
     #[event]
@@ -31,6 +34,7 @@ mod EscrowContract {
     pub enum Event {
         ApproveTransaction: ApproveTransaction,
         EscrowInitialized: EscrowInitialized,
+        EscrowFunded: EscrowFunded
     }
 
     #[derive(Drop, starknet::Event)]
@@ -49,6 +53,14 @@ mod EscrowContract {
         amount: u256,
         timestamp: u64,
     }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct EscrowFunded {
+        depositor: ContractAddress,
+        amount: u256,
+        escrow_address: ContractAddress,
+    }
+
     #[constructor]
     fn constructor(
         ref self: ContractState,
@@ -168,6 +180,34 @@ mod EscrowContract {
                     ),
                 );
         }
+
+        fn fund_escrow(
+            ref self: ContractState, escrow_id: u64, amount: u256, token_address: ContractAddress,
+        ) {
+            // check if escrow exists
+            assert(self.escrow_exists.entry(escrow_id).read(), 'Escrow not exists.');
+            // seting needed variables
+            let depositor = self.depositor.read();
+            let caller_address = get_caller_address();
+            let contract_address = get_contract_address();
+            let expected_amount = self.escrow_amounts.entry(escrow_id).read();
+            // Make an assert the check if the caller address is the same as the depositor address.
+            assert(depositor == caller_address, 'Only depositor can fund.');
+            // Check that the correct amount was sended.
+            assert(amount >= expected_amount, 'Amount is less than expected');
+            
+            //// First Modify in-contract state to avoid reentrancy attacks
+            // Set escrow to funded
+            self.escrow_funded.entry(escrow_id).write(true);
+            
+            // Use the OpenZeppelin ERC20 contract to transfer the fund from the caller address to the
+            // scrow contract.
+            let token = IERC20Dispatcher { contract_address: token_address };
+            token.transfer_from(caller_address, contract_address, amount);
+            // Emit Escrow funded Event
+            self.emit(EscrowFunded { depositor, amount, escrow_address: contract_address });
+        }
+
 
         fn get_depositor(self: @ContractState) -> ContractAddress {
             self.depositor.read()

--- a/src/interface/iescrow.cairo
+++ b/src/interface/iescrow.cairo
@@ -14,4 +14,7 @@ pub trait IEscrow<TContractState> {
     fn get_escrow_details(ref self: TContractState, escrow_id: u256) -> Escrow;
     fn get_depositor(self: @TContractState) -> ContractAddress;
     fn get_beneficiary(self: @TContractState) -> ContractAddress;
+    fn fund_escrow(
+        ref self: TContractState, escrow_id: u64, amount: u256, token_address: ContractAddress,
+    );
 }


### PR DESCRIPTION
#### Implementation of the fund_escrow function to escrow_contract. The function implements the next algorithm:

- Make an assert the check if the caller address is the same as the depositor address.
- Use the OpenZeppelin ERC20 contract to transfer the fund from the caller address to the scrow contract.
- Update the escrow's balance in the Storage -> I create an escrow_balance variable on storage.
- Emit Escrow funded Event -> This event was created and added to the Events enum.