### PR TITLE
test: fund_escrow functionality

### DIFF
--- a/src/escrow/escrow_contract.cairo
+++ b/src/escrow/escrow_contract.cairo
@@ -1,5 +1,5 @@
 #[starknet::contract]
-mod EscrowContract {
+pub mod EscrowContract {
     use core::num::traits::Zero;
     use starknet::{ContractAddress, storage::Map, contract_address_const};
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess, StoragePathEntry};
@@ -47,56 +47,56 @@ mod EscrowContract {
 
     #[derive(Drop, starknet::Event)]
     pub struct DepositorApproved {
-        depositor: ContractAddress,
-        escrow_id: u64,
-        time_of_approval: u64,
+        pub depositor: ContractAddress,
+        pub escrow_id: u64,
+        pub time_of_approval: u64,
     }
 
     #[derive(Drop, starknet::Event)]
     pub struct ArbiterApproved {
-        arbiter: ContractAddress,
-        escrow_id: u64,
-        time_of_approval: u64,
+        pub arbiter: ContractAddress,
+        pub escrow_id: u64,
+        pub time_of_approval: u64,
     }
 
     // Event for escrow initialization
     #[derive(Drop, starknet::Event)]
     pub struct EscrowInitialized {
-        escrow_id: u64,
-        beneficiary: ContractAddress,
-        provider: ContractAddress,
-        amount: u256,
-        timestamp: u64,
+        pub escrow_id: u64,
+        pub beneficiary: ContractAddress,
+        pub provider: ContractAddress,
+        pub amount: u256,
+        pub timestamp: u64,
     }
 
     #[derive(Drop, starknet::Event)]
     pub struct EscrowRefunded {
-        escrow_id: u64,
-        depositor: ContractAddress,
-        amount: u256,
-        timestamp: u64,
+        pub escrow_id: u64,
+        pub depositor: ContractAddress,
+        pub amount: u256,
+        pub timestamp: u64,
     }
 
 
     #[derive(Drop, starknet::Event)]
     pub struct EscrowFunded {
-        depositor: ContractAddress,
-        amount: u256,
-        escrow_address: ContractAddress,
+        pub depositor: ContractAddress,
+        pub amount: u256,
+        pub escrow_address: ContractAddress,
     }
 
     #[derive(Drop, starknet::Event)]
     pub struct RefundEscrow {
-        depositor: ContractAddress,
-        amount: u256,
-        escrow_address: ContractAddress,
+        pub depositor: ContractAddress,
+        pub amount: u256,
+        pub escrow_address: ContractAddress,
     }
 
     #[derive(Drop, starknet::Event)]
     pub struct FundsReleased {
-        escrow_id: u64,
-        beneficiary: ContractAddress,
-        amount: u256,
+        pub escrow_id: u64,
+        pub beneficiary: ContractAddress,
+        pub amount: u256,
     }
 
     #[constructor]

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,3 +1,4 @@
 pub mod escrow;
 pub mod interface;
 pub mod escrownet;
+pub mod mocks;

--- a/src/mocks.cairo
+++ b/src/mocks.cairo
@@ -1,0 +1,1 @@
+pub mod ERC20;

--- a/src/mocks/ERC20.cairo
+++ b/src/mocks/ERC20.cairo
@@ -1,0 +1,34 @@
+#[starknet::contract]
+mod USDT {
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use starknet::ContractAddress;
+
+    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+
+    // ERC20 Mixin
+    #[abi(embed_v0)]
+    impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
+    impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        erc20: ERC20Component::Storage
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        ERC20Event: ERC20Component::Event
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, initial_supply: u256, recipient: ContractAddress) {
+        let name = "USDT";
+        let symbol = "USDT";
+
+        self.erc20.initializer(name, symbol);
+        self.erc20.mint(recipient, initial_supply);
+    }
+}

--- a/tests/test_escrow.cairo
+++ b/tests/test_escrow.cairo
@@ -1,3 +1,4 @@
+use escrownet_contract::interface::ierc20::IERC20DispatcherTrait;
 use escrownet_contract::interface::iescrow::IEscrowDispatcherTrait;
 use starknet::ContractAddress;
 
@@ -6,8 +7,10 @@ use snforge_std::{
     stop_cheat_caller_address, start_cheat_block_timestamp, stop_cheat_block_timestamp, spy_events,
     EventSpyAssertionsTrait,
 };
+use escrownet_contract::interface::ierc20::{IERC20Dispatcher};
 use escrownet_contract::interface::iescrow::{IEscrowDispatcher};
 use escrownet_contract::escrow::errors::Errors;
+use escrownet_contract::escrow::escrow_contract::EscrowContract;
 
 fn BENEFICIARY() -> ContractAddress {
     'benefeciary'.try_into().unwrap()
@@ -21,10 +24,14 @@ fn ARBITER() -> ContractAddress {
     'arbiter'.try_into().unwrap()
 }
 
+fn OTHER() -> ContractAddress {
+    'other'.try_into().unwrap()
+}
+
 // *************************************************************************
 //                              SETUP
 // *************************************************************************
-fn __setup__() -> ContractAddress {
+fn __setup__() -> (ContractAddress, ContractAddress) {
     // deploy  Esrownet
     let escrow_class_hash = declare("EscrowContract").unwrap().contract_class();
 
@@ -42,18 +49,25 @@ fn __setup__() -> ContractAddress {
         .deploy(@escrow_constructor_calldata)
         .unwrap();
 
-    return (escrow_contract_address);
+    // deploy mock USDT
+    let usdt_contract = declare("USDT").unwrap().contract_class();
+    let (usdt_contract_address, _) = usdt_contract
+        .deploy(@array![1000000000000000000000, 0, 'depositor'])
+        .unwrap();
+
+    return (escrow_contract_address, usdt_contract_address);
 }
 #[test]
 fn test_setup() {
-    let contract_address = __setup__();
+    let (contract_address, usdt_contract_address) = __setup__();
 
     println!("Deployed address: {:?}", contract_address);
+    println!("Deploye USDT address: {:?}", usdt_contract_address);
 }
 
 #[test]
 fn test_initialize_escrow() {
-    let contract_address = __setup__();
+    let (contract_address, _) = __setup__();
     println!("Deployed address: {:?}", contract_address);
 
     let escrow_contract_dispatcher = IEscrowDispatcher { contract_address };
@@ -77,4 +91,164 @@ fn test_initialize_escrow() {
     assert(escrow_data.amount == 250, Errors::INVALID_AMOUNT);
 
     stop_cheat_caller_address(contract_address);
+}
+
+#[test]
+fn test_fund_escrow() {
+    let (contract_address, usdt_contract_address) = __setup__();
+    println!("Deployed address: {:?}", contract_address);
+
+    let escrow_contract_dispatcher = IEscrowDispatcher { contract_address };
+    let erc20_dispatcher = IERC20Dispatcher { contract_address: usdt_contract_address };
+
+    let escrow_id: u64 = 7;
+    let benefeciary_address = BENEFICIARY();
+    let provider_address = starknet::contract_address_const::<0x124>();
+    let amount: u256 = 250;
+
+    let depositor = DEPOSITOR();
+
+    start_cheat_caller_address(contract_address, depositor);
+
+    escrow_contract_dispatcher
+        .initialize_escrow(escrow_id, benefeciary_address, provider_address, amount);
+
+    let escrow_data = escrow_contract_dispatcher.get_escrow_details(7);
+
+    assert(escrow_data.amount == amount, Errors::INVALID_AMOUNT);
+
+    stop_cheat_caller_address(contract_address);
+
+    start_cheat_caller_address(usdt_contract_address, depositor);
+    erc20_dispatcher.approve(contract_address, amount);
+    stop_cheat_caller_address(usdt_contract_address);
+
+    start_cheat_caller_address(contract_address, depositor);
+    escrow_contract_dispatcher.fund_escrow(escrow_id, amount, usdt_contract_address);
+
+    assert(
+        escrow_contract_dispatcher.is_escrow_funded(escrow_id) == true, Errors::ESCROW_NOT_FUNDED
+    );
+
+    stop_cheat_caller_address(contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'Only depositor can fund.')]
+fn test_only_depositor_can_fund_escrow() {
+    let (contract_address, usdt_contract_address) = __setup__();
+    println!("Deployed address: {:?}", contract_address);
+
+    let escrow_contract_dispatcher = IEscrowDispatcher { contract_address };
+
+    let escrow_id: u64 = 7;
+    let benefeciary_address = BENEFICIARY();
+    let provider_address = starknet::contract_address_const::<0x124>();
+    let amount: u256 = 250;
+
+    let depositor = DEPOSITOR();
+    let other = OTHER();
+
+    start_cheat_caller_address(contract_address, depositor);
+
+    escrow_contract_dispatcher
+        .initialize_escrow(escrow_id, benefeciary_address, provider_address, amount);
+
+    let escrow_data = escrow_contract_dispatcher.get_escrow_details(7);
+
+    assert(escrow_data.amount == 250, Errors::INVALID_AMOUNT);
+    stop_cheat_caller_address(contract_address);
+
+    start_cheat_caller_address(contract_address, other);
+
+    escrow_contract_dispatcher.fund_escrow(escrow_id, amount, usdt_contract_address);
+    stop_cheat_caller_address(contract_address);
+}
+
+
+#[test]
+#[should_panic(expected: 'Amount is less than expected')]
+fn test_can_not_fund_escrow_with_wrong_amount() {
+    let (contract_address, usdt_contract_address) = __setup__();
+    println!("Deployed address: {:?}", contract_address);
+
+    let escrow_contract_dispatcher = IEscrowDispatcher { contract_address };
+
+    let escrow_id: u64 = 7;
+    let benefeciary_address = BENEFICIARY();
+    let provider_address = starknet::contract_address_const::<0x124>();
+    let amount: u256 = 250;
+
+    let depositor = DEPOSITOR();
+    let other = OTHER();
+
+    start_cheat_caller_address(contract_address, depositor);
+
+    escrow_contract_dispatcher
+        .initialize_escrow(escrow_id, benefeciary_address, provider_address, amount);
+
+    let escrow_data = escrow_contract_dispatcher.get_escrow_details(7);
+
+    assert(escrow_data.amount == 250, Errors::INVALID_AMOUNT);
+
+    escrow_contract_dispatcher.fund_escrow(escrow_id, 200, usdt_contract_address);
+    stop_cheat_caller_address(contract_address);
+}
+
+
+#[test]
+fn test_fund_escrow_event_emission() {
+    let (contract_address, usdt_contract_address) = __setup__();
+    println!("Deployed address: {:?}", contract_address);
+
+    let escrow_contract_dispatcher = IEscrowDispatcher { contract_address };
+    let erc20_dispatcher = IERC20Dispatcher { contract_address: usdt_contract_address };
+
+    let mut spy = spy_events();
+
+    let escrow_id: u64 = 7;
+    let benefeciary_address = BENEFICIARY();
+    let provider_address = starknet::contract_address_const::<0x124>();
+    let amount: u256 = 250;
+
+    let depositor = DEPOSITOR();
+
+    start_cheat_caller_address(contract_address, depositor);
+
+    escrow_contract_dispatcher
+        .initialize_escrow(escrow_id, benefeciary_address, provider_address, amount);
+
+    let escrow_data = escrow_contract_dispatcher.get_escrow_details(7);
+
+    assert(escrow_data.amount == amount, Errors::INVALID_AMOUNT);
+
+    stop_cheat_caller_address(contract_address);
+
+    start_cheat_caller_address(usdt_contract_address, depositor);
+    erc20_dispatcher.approve(contract_address, amount);
+    stop_cheat_caller_address(usdt_contract_address);
+
+    start_cheat_caller_address(contract_address, depositor);
+    escrow_contract_dispatcher.fund_escrow(escrow_id, amount, usdt_contract_address);
+
+    assert(
+        escrow_contract_dispatcher.is_escrow_funded(escrow_id) == true, Errors::ESCROW_NOT_FUNDED
+    );
+
+    stop_cheat_caller_address(contract_address);
+
+    // check events are emitted
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    contract_address,
+                    EscrowContract::Event::EscrowFunded(
+                        EscrowContract::EscrowFunded {
+                            depositor, amount, escrow_address: contract_address
+                        }
+                    )
+                )
+            ]
+        );
 }


### PR DESCRIPTION
## ✅ Add Tests for `fund_escrow` Function

### 🔍 Overview

This pull request adds a complete test suite for the `fund_escrow` function to ensure proper behavior, security, and event handling. These tests help verify that only authorized users can fund the escrow, correct conditions are enforced, and the expected event is emitted.

---

### 🧪 Tests Added

- **`test_fund_escrow`**  
  Validates successful funding flow under the correct conditions: valid depositor, approved token, and correct amount.

- **`test_only_depositor_can_fund_escrow`**  
  Ensures that only the designated depositor can call the `fund_escrow` function.  
  ✅ The test expects a panic when a different user tries to fund.

- **`test_can_not_fund_escrow_with_wrong_amount`**  
  Confirms that funding with an incorrect (less than required) amount causes the function to revert with the expected error.

- **`test_fund_escrow_event_emission`**  
  Verifies that a successful funding triggers the correct `EscrowFunded` event with the right parameters.

---

### 🔐 Why This Matters

- Ensures **access control** by restricting function calls to the depositor.
- Enforces **input validation** for the funding amount.
- Confirms **event emission** for observability and off-chain consumption.
- Strengthens the **security and reliability** of the escrow mechanism.

---

### 📦 Related Issue

Closes #52
